### PR TITLE
Passing the args given to test.watch to passing them to the test command

### DIFF
--- a/lib/mix_test_watch.ex
+++ b/lib/mix_test_watch.ex
@@ -2,13 +2,13 @@ defmodule Mix.Tasks.Test.Watch do
   use Mix.Task
   use GenServer
 
-  def run(_) do
-    setup
+  def run(args) do
+    setup(args)
     :timer.sleep :infinity
   end
 
-  def setup do
-    Agent.start_link( fn -> true end, name: :mix_test_watch_state )
+  def setup(args) do
+    Agent.start_link( fn -> %{ not_running_tests?: true, args: args} end, name: :mix_test_watch_state )
     Application.start :fs
     GenServer.start_link( __MODULE__, [], name: __MODULE__ )
   end
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Test.Watch do
   end
 
   defp not_running_tests? do
-    Agent.get( :mix_test_watch_state, fn x -> x end )
+    Agent.get( :mix_test_watch_state, fn x -> x.not_running_tests? end )
   end
 
   defp watching?(path) do
@@ -35,13 +35,13 @@ defmodule Mix.Tasks.Test.Watch do
 
   defp run_tests(agent \\ :mix_test_watch_state) do
     IO.puts "Running tests..."
-    Agent.update( agent, fn _ -> false end )
-    IO.puts( to_string :os.cmd(mix_cmd) )
-    Agent.update( agent, fn _ -> true end )
+    args = Agent.get_and_update( agent, fn x -> { x.args, %{ x | not_running_tests?: false } } end )
+    IO.puts( to_string :os.cmd(mix_cmd(args)) )
+    Agent.update( agent, fn x -> %{ x | not_running_tests?: true } end )
   end
 
-  defp mix_cmd do
+  defp mix_cmd(args) do
     ansi = "Application.put_env(:elixir, :ansi_enabled, true);"
-    to_char_list ~s[MIX_ENV=test mix do run -e '#{ansi}', test]
+    to_char_list ~s[MIX_ENV=test mix do run -e '#{ansi}', test #{Enum.join(args, " ")}]
   end
 end


### PR DESCRIPTION
Awesome command! I saw your post on the mailing list and the only thing I had to add was the ability take the args and pass them to the test command. Just in case you only want to watch a subset of the tests.