### PR TITLE
Forward commandline arguments to command builder

### DIFF
--- a/lib/mix/tasks/test/watch.ex
+++ b/lib/mix/tasks/test/watch.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Test.Watch do
     args     = Enum.join(args, " ")
     :ok      = Application.start :fs, :permanent
     {:ok, _} = GenServer.start_link( __MODULE__, args, name: __MODULE__ )
-    run_tests
+    run_tests(args)
     :timer.sleep :infinity
   end
 
@@ -46,9 +46,9 @@ defmodule Mix.Tasks.Test.Watch do
 
   @spec run_tests(String.t) :: :ok
 
-  defp run_tests(_args \\ "") do
+  defp run_tests(args) do
     IO.puts "\nRunning tests..."
-    :ok = M.Command.build |> M.Command.exec
+    :ok = args |> M.Command.build |> M.Command.exec
     flush
     :ok
   end

--- a/lib/mix_test_watch/command.ex
+++ b/lib/mix_test_watch/command.ex
@@ -11,10 +11,10 @@ defmodule MixTestWatch.Command do
   @doc """
   Builds the shell command that runs the desired mix task(s).
   """
-  def build do
+  def build(args \\ nil) do
     command =
       tasks
-      |> Enum.map(&task_command/1)
+      |> Enum.map(&task_command(&1, args))
       |> Enum.join(" && ")
     ~s(sh -c "#{command}")
   end
@@ -40,8 +40,10 @@ defmodule MixTestWatch.Command do
     Application.get_env(:mix_test_watch, :prefix, @default_prefix)
   end
 
-  defp task_command(task) do
-    ~s(MIX_ENV=test #{prefix} do #{ansi}, #{task})
+  defp task_command(task, args) do
+    ["MIX_ENV=test", prefix, "do", ansi <> ",", task, args]
+    |> Enum.filter(&(&1))
+    |> Enum.join(" ")
   end
 
 

--- a/test/mix_test_watch/command_test.exs
+++ b/test/mix_test_watch/command_test.exs
@@ -6,6 +6,16 @@ defmodule MixTestWatch.CommandTest do
 
   alias MixTestWatch.Command
 
+  test "build appends commandline arguments" do
+    args = "test/mix_test_watch/command_test.exs:15"
+    expected = ~s(sh -c "MIX_ENV=test mix do run -e )
+            <> "'Application.put_env(:elixir, :ansi_enabled, true);'"
+            <> ~s(, test test/mix_test_watch/command_test.exs:15")
+    TemporaryEnv.delete :mix_test_watch, :tasks do
+      assert Command.build(args) == expected
+    end
+  end
+
   test "build returns a sensible default command" do
     expected = ~s(sh -c "MIX_ENV=test mix do run -e )
             <> "'Application.put_env(:elixir, :ansi_enabled, true);'"


### PR DESCRIPTION
The commandline arguments seems to have been lost during some refactoring.
This commit restores the support to be able to run ```mix test.watch test/mix_test_watch/command_test.exs:15``` or  ```mix test.watch integration``` to be able to watch custom files and directories just like the normal mix `test` task.