### PR TITLE
allow MIX_ENV to be overriden by environment variable

### DIFF
--- a/lib/mix_test_watch/command.ex
+++ b/lib/mix_test_watch/command.ex
@@ -5,6 +5,7 @@ defmodule MixTestWatch.Command do
 
   @default_tasks ~w(test)a
   @default_prefix "mix"
+  @mix_env System.get_env("MIX_ENV") || "test"
 
   @spec build :: String.t
 
@@ -41,7 +42,7 @@ defmodule MixTestWatch.Command do
   end
 
   defp task_command(task, args) do
-    ["MIX_ENV=test", prefix, "do", ansi <> ",", task, args]
+    ["MIX_ENV=#{@mix_env}", prefix, "do", ansi <> ",", task, args]
     |> Enum.filter(&(&1))
     |> Enum.join(" ")
   end


### PR DESCRIPTION
Hello,
I found myself in need to override the default environment for tests, which defaults to `MIX_ENV=test`, as you correctly noted.
With this pull-request the default `MIX_ENV` is still `test`, but it can be overridden.

PS: thanks for this :)

:wq