### PR TITLE
on file change run single test first

### DIFF
--- a/lib/mix_test_watch/files.ex
+++ b/lib/mix_test_watch/files.ex
@@ -1,0 +1,19 @@
+defmodule MixTestWatch.Files do
+  @moduledoc """
+  Finds corresponding test file for any given file.
+  """
+
+  @spec find_test(String.t) :: String.t
+
+  def find_test(impl) do
+    candidate = impl
+      |> String.replace("web/", "test/")
+      |> String.replace("lib/", "test/")
+      |> String.replace(~r/\.ex$/, "_test.exs")
+    if File.exists?(candidate) do
+      candidate
+    else
+      nil
+    end
+  end
+end

--- a/lib/mix_test_watch/run.ex
+++ b/lib/mix_test_watch/run.ex
@@ -1,0 +1,51 @@
+defmodule MixTestWatch.Run do
+  @moduledoc """
+  Runs tests according to given path
+  """
+
+  alias MixTestWatch.Command
+  alias MixTestWatch.Files
+  alias MixTestWatch.Shell
+
+  @spec run(String.t, String.t) :: :ok
+
+  def run(path, config) do
+    case run_single( path, config ) do
+      :ok      -> run_tests( config )   # single test found and successful
+      :no_test -> run_tests( config )   # single test not found
+      _        -> true                  # single test found but unsuccessful
+    end
+  end
+
+  @spec run_tests(String.t) :: :ok
+
+  def run_tests(config) do
+    config |> Command.build |> Shell.exec
+  end
+
+  @spec run_single(String.t, String.t) :: :ok
+
+  defp run_single(path, config) do
+    if test_file?(path) do
+      run_tests config.args <> " " <> path
+    else
+      case Files.find_test(path) do
+        nil   ->
+          IO.puts "\nIgnoring #{path}"
+          :no_test
+        found ->
+          run_single(found, config)
+      end
+    end
+  end
+
+  @spec test_file?(String.t) :: boolean
+
+  defp test_file?(path) do
+    pwd    = Path.absname("./")
+    path
+      |> Path.relative_to(pwd)
+      |> String.starts_with?("test/")
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.Test.Watch.Mixfile do
       app: :mix_test_watch,
       version: @version,
       elixir: "~> 1.0",
+      elixirc_paths: elixirc_paths(Mix.env),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps,
@@ -27,6 +28,10 @@ defmodule Mix.Tasks.Test.Watch.Mixfile do
       applications: []
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   defp deps do
     [

--- a/test/mix_test_watch/files_test.exs
+++ b/test/mix_test_watch/files_test.exs
@@ -1,0 +1,34 @@
+defmodule MixTestWatch.FilesTest do
+  use ExUnit.Case
+  import MixTestWatch.MockFsHelper
+
+  import MixTestWatch.Files, only: [find_test: 1]
+
+  test "test files are responsible for themselved" do
+    tfile = "test/foo/bar_test.exs"
+    with_mock_fs [tfile] do
+      assert fs(tfile) == find_test(fs tfile)
+    end
+  end
+
+  test "finds test file for implementation in lib/" do
+    tfile = "test/bar/foo_test.exs"
+    with_mock_fs [tfile] do
+      assert fs(tfile) == find_test(fs "lib/bar/foo.ex")
+    end
+  end
+
+  test "finds test file for implementation in web/ (for phoenix)" do
+    tfile = "test/models/plant_test.exs"
+    with_mock_fs [tfile] do
+      assert fs(tfile) == find_test(fs "web/models/plant.ex")
+    end
+  end
+
+  test "finds nothing when test file does not exist" do
+    with_mock_fs [] do
+      assert nil == find_test(fs "lib/bar/foo.ex")
+    end
+  end
+
+end

--- a/test/mix_test_watch/run_test.exs
+++ b/test/mix_test_watch/run_test.exs
@@ -1,0 +1,5 @@
+defmodule MixTestWatch.RunTest do
+  use ExUnit.Case
+
+  # TODO: no clue how to properly test MixTestWatch.Run
+end

--- a/test/support/mock_fs_helper.ex
+++ b/test/support/mock_fs_helper.ex
@@ -1,0 +1,49 @@
+defmodule MixTestWatch.MockFsHelper do
+  @moduledoc """
+  Sets up a temporary file system to be used in tests which need real files to
+  exist. Paths in the given list will be touched before running the block and
+  will be cleanup up afterwards.
+
+    test "files exist when passed to macro" do
+      file = "thefn0rd.txt"
+      with_mock_fs [file] do
+        assert File.exist?(fs file)
+      end
+    end
+
+  Notices the usage of the `fs` macro to get the real path within the temporary
+  file system.
+  """
+
+  @root "tmp/fs"
+  import Path, only: [join: 2]
+
+  defmacro with_mock_fs(files, test) do
+    quote do
+      try do
+        if File.dir?(unquote(@root)) do # tabula rasa
+          File.rm_rf(unquote(@root))
+        end
+        File.mkdir_p(unquote(@root))    # empty save space
+        Enum.each unquote(files), fn (file)->
+          if String.contains?(file, "..") do
+            raise "no shenanigans with '..'" # keep bumblebees to a minimum
+          end
+          path = join(unquote(@root), file)
+          :ok = File.mkdir_p( Path.dirname(path) )
+          :ok = File.touch(path)
+        end
+        # Run all the tests inside the filesystem
+        unquote(test)
+      after
+        File.rm_rf(unquote(@root))
+      end
+    end
+  end
+
+  defmacro fs(path) do
+    quote do
+      join(unquote(@root), unquote(path))
+    end
+  end
+end


### PR DESCRIPTION
When a watched test file is changed, run it with mix test. If the unix
error code is 0 (successful), run the complete suite.
When the file is not in the test directory, try to find a corresponding
test file following elixir conventions and run that instead.

This should speed up TDD extremely. Resolves lpil/mix-test.watch#12.


PS: I am new to elixir, so I might have missed some idioms. :angel: :goat: 