### PR TITLE
added an option to clear the console before run

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Note that if you have configured more than one task to be run these arguments
 will be passed to all the tasks run, not just the test command.
 
 
+## Clearing the Console before each run
+
+If you want mix test.watch to clear the console before each run, you can enable 
+this option in your config/dev.exs as follows :
+
+```elixir
+config :mix_test_watch,
+  clear: true
+```
+
 ## Compatibility Notes
 
 On Linux you may need to install `inotify-tools`.

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Note that if you have configured more than one task to be run these arguments
 will be passed to all the tasks run, not just the test command.
 
 
-## Clearing the Console before each run
+## Clearing the console before each run
 
 If you want mix test.watch to clear the console before each run, you can enable 
-this option in your config/dev.exs as follows :
+this option in your config/dev.exs as follows:
 
 ```elixir
 config :mix_test_watch,

--- a/lib/mix/tasks/test/watch.ex
+++ b/lib/mix/tasks/test/watch.ex
@@ -51,9 +51,14 @@ defmodule Mix.Tasks.Test.Watch do
   @spec run_tests(String.t) :: :ok
 
   defp run_tests(config) do
+    maybe_clear(config)
     IO.puts "\nRunning tests..."
     :ok = config |> Command.build |> Shell.exec
     Message.flush
     :ok
   end
+
+  defp maybe_clear(%{clear: false}), do: nil
+  defp maybe_clear(%{clear: true}), do: IO.puts IO.ANSI.clear
+
 end

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -5,9 +5,11 @@ defmodule MixTestWatch.Config do
 
   @default_tasks ~w(test)
   @default_prefix "mix"
+  @default_clear false
 
   defstruct tasks:    @default_tasks,
             prefix:   @default_prefix,
+            clear:    @default_clear,
             cli_args: ""
 
 
@@ -20,6 +22,7 @@ defmodule MixTestWatch.Config do
     %__MODULE__{
       tasks:    get_tasks(),
       prefix:   get_prefix(),
+      clear:    get_clear(),
       cli_args: args,
     }
   end
@@ -31,5 +34,9 @@ defmodule MixTestWatch.Config do
 
   defp get_prefix do
     Application.get_env(:mix_test_watch, :prefix, @default_prefix)
+  end
+
+  defp get_clear do
+    Application.get_env(:mix_test_watch, :clear, @default_clear)
   end
 end

--- a/test/mix_test_watch/config_test.exs
+++ b/test/mix_test_watch/config_test.exs
@@ -42,4 +42,12 @@ defmodule MixTestWatch.ConfigTest do
     config = Config.new
     assert config.cli_args == ""
   end
+
+  test "new/1 takes :clear from the env" do
+    TemporaryEnv.set :mix_test_watch, clear: true do
+      config = Config.new
+      assert config.clear
+    end
+  end
+
 end


### PR DESCRIPTION
I like the option to have a clear console that only contains the results of the last test run.
This option clears the console before each  new run which you can set by adding
```
config :mix_test_watch, clear: true
```

to dev.exs.

Hope you will find this option as useful as I do :)

Gerard.