### PR TITLE
Windows support

### DIFF
--- a/lib/mix_test_watch/command.ex
+++ b/lib/mix_test_watch/command.ex
@@ -4,6 +4,7 @@ defmodule MixTestWatch.Command do
   """
 
   alias MixTestWatch.Config
+  alias MixTestWatch.Environment, as: Env
 
   @spec build(%Config{}) :: String.t
 
@@ -11,16 +12,15 @@ defmodule MixTestWatch.Command do
   Builds the shell command that runs the desired mix task(s).
   """
   def build(config) do
-    command =
-      config.tasks
-      |> Enum.map(&task_command(&1, config))
-      |> Enum.join(" && ")
-    ~s(sh -c "#{command}")
+    config.tasks
+    |> Enum.map(&task_command(&1, config))
+    |> Enum.join(" && ")
+    |> Env.shell_launch
   end
 
 
   defp task_command(task, config) do
-    ["MIX_ENV=test", config.prefix, "do", ansi <> ",", task, config.cli_args]
+    [Env.set_var("MIX_ENV", "test", :chained), config.prefix, "do", ansi <> ",", task, config.cli_args]
     |> Enum.filter(&(&1))
     |> Enum.join(" ")
   end
@@ -28,6 +28,7 @@ defmodule MixTestWatch.Command do
 
   @spec ansi :: String.t
   defp ansi do
-    "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+    put_env = Env.escaped_quote("Application.put_env(:elixir, :ansi_enabled, true);")
+    "run -e " <> put_env
   end
 end

--- a/lib/mix_test_watch/command.ex
+++ b/lib/mix_test_watch/command.ex
@@ -20,7 +20,8 @@ defmodule MixTestWatch.Command do
 
 
   defp task_command(task, config) do
-    [Env.set_var("MIX_ENV", "test", :chained), config.prefix, "do", ansi <> ",", task, config.cli_args]
+    set_var = Env.set_var("MIX_ENV", "test", :chained)
+    [set_var, config.prefix, "do", ansi <> ",", task, config.cli_args]
     |> Enum.filter(&(&1))
     |> Enum.join(" ")
   end
@@ -28,7 +29,8 @@ defmodule MixTestWatch.Command do
 
   @spec ansi :: String.t
   defp ansi do
-    put_env = Env.escaped_quote("Application.put_env(:elixir, :ansi_enabled, true);")
+    put_env =
+      Env.escaped_quote("Application.put_env(:elixir, :ansi_enabled, true);")
     "run -e " <> put_env
   end
 end

--- a/lib/mix_test_watch/environment.ex
+++ b/lib/mix_test_watch/environment.ex
@@ -1,18 +1,54 @@
 defmodule MixTestWatch.Environment do
+  @moduledoc """
+  Responsible for Environment-specific behavior/syntax
+  """
+
   if match? {:win32, _}, :os.type do
+
+    @spec shell_launch(String.t) :: String.t
+
+    @doc """
+    Builds shell launch command
+    """
     def shell_launch(cmd), do: ~s(cmd /c "#{cmd}")
-    
+
+    @spec escaped_quote(String.t) :: String.t
+
+    @doc """
+    Wraps string around escaped quotes in the shell
+    """
     def escaped_quote(content), do: "^\"#{content}^\""
 
-    def set_var(name, val, chained \\ false) do 
+    @spec set_var(String.t, String.t) :: String.t
+
+    @doc """
+    Builds environment variable set command for the shell
+    """
+    def set_var(name, val, chained \\ false) do
       cmd = "set \"#{name}=#{val}\""
       if chained == :chained, do: cmd <> " &&", else: cmd
     end
   else
+
+    @spec shell_launch(String.t) :: String.t
+
+    @doc """
+    Builds shell launch command
+    """
     def shell_launch(cmd), do: ~s(sh -c "#{cmd}")
-    
+
+    @spec escaped_quote(String.t) :: String.t
+
+    @doc """
+    Wraps string around escaped quotes in the shell
+    """
     def escaped_quote(content), do: "'#{content}'"
 
+    @spec set_var(String.t, String.t) :: String.t
+
+    @doc """
+    Builds environment variable set command for the shell
+    """
     def set_var(name, val, _), do: "#{name}=#{val}"
   end
 end

--- a/lib/mix_test_watch/environment.ex
+++ b/lib/mix_test_watch/environment.ex
@@ -19,7 +19,7 @@ defmodule MixTestWatch.Environment do
     """
     def escaped_quote(content), do: "^\"#{content}^\""
 
-    @spec set_var(String.t, String.t) :: String.t
+    @spec set_var(String.t, String.t, String.t) :: String.t
 
     @doc """
     Builds environment variable set command for the shell
@@ -44,7 +44,7 @@ defmodule MixTestWatch.Environment do
     """
     def escaped_quote(content), do: "'#{content}'"
 
-    @spec set_var(String.t, String.t) :: String.t
+    @spec set_var(String.t, String.t, String.t) :: String.t
 
     @doc """
     Builds environment variable set command for the shell

--- a/lib/mix_test_watch/environment.ex
+++ b/lib/mix_test_watch/environment.ex
@@ -1,0 +1,18 @@
+defmodule MixTestWatch.Environment do
+  if match? {:win32, _}, :os.type do
+    def shell_launch(cmd), do: ~s(cmd /c "#{cmd}")
+    
+    def escaped_quote(content), do: "^\"#{content}^\""
+
+    def set_var(name, val, chained \\ false) do 
+      cmd = "set \"#{name}=#{val}\""
+      if chained == :chained, do: cmd <> " &&", else: cmd
+    end
+  else
+    def shell_launch(cmd), do: ~s(sh -c "#{cmd}")
+    
+    def escaped_quote(content), do: "'#{content}'"
+
+    def set_var(name, val, _), do: "#{name}=#{val}"
+  end
+end

--- a/lib/mix_test_watch/environment.ex
+++ b/lib/mix_test_watch/environment.ex
@@ -4,6 +4,11 @@ defmodule MixTestWatch.Environment do
   """
 
   if match? {:win32, _}, :os.type do
+    @spec windows? :: boolean
+    @doc """
+    Returns true if we're on windows
+    """
+    def windows?, do: true
 
     @spec shell_launch(String.t) :: String.t
 
@@ -29,6 +34,11 @@ defmodule MixTestWatch.Environment do
       if chained == :chained, do: cmd <> " &&", else: cmd
     end
   else
+    @spec windows? :: boolean
+    @doc """
+    Returns true if we're on windows
+    """
+    def windows?, do: false
 
     @spec shell_launch(String.t) :: String.t
 

--- a/lib/mix_test_watch/shell.ex
+++ b/lib/mix_test_watch/shell.ex
@@ -9,7 +9,7 @@ defmodule MixTestWatch.Shell do
   Runs a given shell command, steaming the output to STDOUT
   """
   def exec(exe) do
-    args = ~w(stream binary exit_status use_stdio stderr_to_stdout)a
+    args = ~w(stream binary exit_status use_stdio hide stderr_to_stdout)a
     {:spawn, exe} |> Port.open(args) |> results_loop
     :ok
   end

--- a/test/mix_test_watch/command_test.exs
+++ b/test/mix_test_watch/command_test.exs
@@ -4,27 +4,48 @@ defmodule MixTestWatch.CommandTest do
 
   alias MixTestWatch.Command
   alias MixTestWatch.Config
+  alias MixTestWatch.Environment, as: Env
 
   test "build appends commandline arguments from passed config" do
     config = %Config{ cli_args: "test/mix_test_watch/command_test.exs:15" }
-    expected = ~s(sh -c "MIX_ENV=test mix do run -e )
-            <> "'Application.put_env(:elixir, :ansi_enabled, true);'"
-            <> ~s(, test test/mix_test_watch/command_test.exs:15")
+    expected =
+      if Env.windows? do
+        ~s(cmd /c "set \"MIX_ENV=test\" && mix do run -e )
+          <> ~s[^"Application.put_env(:elixir, :ansi_enabled, true);^"]
+          <> ~s(, test test/mix_test_watch/command_test.exs:15")
+      else
+        ~s(sh -c "MIX_ENV=test mix do run -e )
+          <> "'Application.put_env(:elixir, :ansi_enabled, true);'"
+          <> ~s(, test test/mix_test_watch/command_test.exs:15")
+      end
     assert Command.build(config) == expected
   end
 
   test "build can take tasks from application env" do
     config = %Config{ tasks: ["dogma do something"] }
-    expected = ~s(sh -c "MIX_ENV=test mix do run -e )
-            <> "'Application.put_env(:elixir, :ansi_enabled, true);'"
-            <> ~s(, dogma do something ")
+    expected =
+      if Env.windows? do
+        ~s(cmd /c "set \"MIX_ENV=test\" && mix do run -e )
+          <> ~s[^"Application.put_env(:elixir, :ansi_enabled, true);^"]
+          <> ~s(, dogma do something ")
+      else
+        ~s(sh -c "MIX_ENV=test mix do run -e )
+          <> "'Application.put_env(:elixir, :ansi_enabled, true);'"
+          <> ~s(, dogma do something ")
+      end
     assert Command.build(config) == expected
   end
 
   test "build can take the command prefix from passed config" do
     config = %Config{ prefix: "iex -S mix" }
-    expected = ~s[sh -c "MIX_ENV=test iex -S mix do run -e ]
-            <> ~s['Application.put_env(:elixir, :ansi_enabled, true);', test "]
+    expected =
+      if Env.windows? do
+        ~s[cmd /c "set \"MIX_ENV=test\" && iex -S mix do run -e ]
+          <> ~s[^"Application.put_env(:elixir, :ansi_enabled, true);^", test "]
+      else
+        ~s[sh -c "MIX_ENV=test iex -S mix do run -e ]
+          <> ~s['Application.put_env(:elixir, :ansi_enabled, true);', test "]
+      end
     assert Command.build(config) == expected
   end
 end


### PR DESCRIPTION
Hey, just got Windows working =]

__I'll squash the commits if you give me an OK, just left them all here for clarity I guess.__

I looked up on the elixir-lang repo for examples of how they deal with environments and found [this](https://github.com/elixir-lang/elixir/blob/e1a1065ee9b389f4fdf0b9b2fad4700be61d43aa/lib/elixir/test/elixir/test_helper.exs#L59):

```elixir
  if match? {:win32, _}, :os.type do
    def windows?, do: true
    def executable_extension, do: ".bat"
    def redirect_std_err_on_win, do: " 2>&1"
  else
    def windows?, do: false
    def executable_extension, do: ""
    def redirect_std_err_on_win, do: ""
  end
```

#### What I changed:

* I used the same style I found on the elixir repo in making Windows work here, putting all environment-specific code in the `Environment.ex` file.
* Chained `set MIX_ENV=test` and `mix do` was not working until I quoted the variable like: `set "MIX_ENV=test" && mix do..`.
* Windows escapes quotes differently, `'` doesn't work inside `""`. I had to escape them with `^"`.
* I put ifs for defining expected values in tests for Windows and non-Windows environments, it's uglier than before, let me know if you have a better idea.
* I had to add the `hide` option to `Port.open` so Windows CMD prompts would stop popping up on the screen on every test run, saw no change in Linux with this, IDK about Mac.

I tested this on Windows 10 x64 and Debian 8.2.