### PR TITLE
Also put cursor home after clearing the terminal

### DIFF
--- a/lib/mix/tasks/test/watch.ex
+++ b/lib/mix/tasks/test/watch.ex
@@ -69,5 +69,5 @@ defmodule Mix.Tasks.Test.Watch do
   end
 
   defp maybe_clear(%{clear: false}), do: nil
-  defp maybe_clear(%{clear: true}), do: IO.puts IO.ANSI.clear
+  defp maybe_clear(%{clear: true}), do: IO.puts(IO.ANSI.clear <> IO.ANSI.home)
 end


### PR DESCRIPTION
This will effectively clear the complete screen and continue output from the top. I thought this might even be more expected behaviour.