### PR TITLE
fixes :mix_test_watch warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ If you want mix test.watch to clear the console before each run, you can
 enable this option in your config/dev.exs as follows:
 
 ```elixir
-config :mix_test_watch,
-  clear: true
+if Mix.env == :dev do      # prevents :mix_test_watch warning, alternatively use a config/dev.exs file
+  config :mix_test_watch,
+    clear: true
+end    
 ```
 
 ## Excluding files or directories


### PR DESCRIPTION
This will fix the error message reported in #28 . 

Manually tested in Phoenix 1.2, Elixir 1.2, Erlang 18 by using the global config.exs and the `if` check as well as without an `if` check inside the `config/dev.exs` file.

I'm not 100% satisfied with the comment verbiage so feel free to tweak it of course. Should at least help prevent confused folks.

Thanks for the hard work on this package btw... much appreciated 🍻 
