### PR TITLE
Add optional timestamp printing

### DIFF
--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -6,11 +6,13 @@ defmodule MixTestWatch.Config do
   @default_runner MixTestWatch.HotRunner
   @default_tasks ~w(test)
   @default_clear false
+  @default_timestamp false
   @default_exclude []
   @default_extra_extensions []
 
   defstruct tasks:            @default_tasks,
             clear:            @default_clear,
+            timestamp:        @default_timestamp,
             runner:           @default_runner,
             exclude:          @default_exclude,
             extra_extensions: @default_extra_extensions,
@@ -25,6 +27,7 @@ defmodule MixTestWatch.Config do
     %__MODULE__{
       tasks:             get_tasks(),
       clear:             get_clear(),
+      timestamp:         get_timestamp(),
       runner:            get_runner(),
       exclude:           get_excluded(),
       cli_args:          cli_args,
@@ -43,6 +46,10 @@ defmodule MixTestWatch.Config do
 
   defp get_clear do
     Application.get_env(:mix_test_watch, :clear, @default_clear)
+  end
+
+  defp get_timestamp do
+    Application.get_env(:mix_test_watch, :timestamp, @default_timestamp)
   end
 
   defp get_excluded do

--- a/lib/mix_test_watch/runner.ex
+++ b/lib/mix_test_watch/runner.ex
@@ -21,6 +21,7 @@ defmodule MixTestWatch.Runner do
   def run(%Config{} = config) do
     :ok = maybe_clear_terminal(config)
     IO.puts "\nRunning tests..."
+    :ok = maybe_print_timestamp(config)
     :ok = config.runner.run(config)
     :ok
   end
@@ -45,4 +46,13 @@ defmodule MixTestWatch.Runner do
     do: :ok
   defp maybe_clear_terminal(%{clear: true}),
     do: :ok = IO.puts(IO.ANSI.clear <> IO.ANSI.home)
+
+  defp maybe_print_timestamp(%{timestamp: false}),
+    do: :ok
+  defp maybe_print_timestamp(%{timestamp: true}) do
+    :ok =
+      DateTime.utc_now
+      |> DateTime.to_string
+      |> IO.puts
+  end
 end

--- a/test/mix_test_watch/config_test.exs
+++ b/test/mix_test_watch/config_test.exs
@@ -49,4 +49,11 @@ defmodule MixTestWatch.ConfigTest do
     end
   end
 
+  test "new/1 takes :timestamp from the env" do
+    TemporaryEnv.set :mix_test_watch, timestamp: true do
+      config = Config.new
+      assert config.timestamp
+    end
+  end
+
 end

--- a/test/mix_test_watch/runner_test.exs
+++ b/test/mix_test_watch/runner_test.exs
@@ -28,5 +28,20 @@ defmodule MixTestWatch.RunnerTest do
       Running tests...
       """
     end
+
+    test "It outputs timestamp when specified by the config" do
+      config = %Config{ runner: DummyRunner, timestamp: true}
+      output = capture_io fn ->
+        Runner.run(config)
+      end
+      assert Agent.get(DummyRunner, fn(x) -> x end) == [config]
+      timestamp = output
+        |> String.replace_leading("""
+
+      Running tests...
+      """, "")
+      |> String.trim
+      assert {:ok, _} = NaiveDateTime.from_iso8601(timestamp)
+    end
   end
 end


### PR DESCRIPTION
This change will print a UTC timestamp after "Running Tests..." for each testing run.