### PR TITLE
Add a setup_tasks to just run once on `mix test.watch` startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add it to your dependencies:
 ```elixir
 # mix.exs (Elixir 1.4)
 def deps do
-  [{:mix_test_watch, "~> 0.3", only: :dev, runtime: false}]  
+  [{:mix_test_watch, "~> 0.3", only: :dev, runtime: false}]
 end
 ```
 
@@ -59,10 +59,31 @@ if Mix.env == :dev do
 end
 ```
 
-Tasks are run in the order they appear in the list, and the progression will
-stop if any command returns a non-zero exit code.
+## Running Additional Mix Tasks On Start Up
 
-All tasks are run with `MIX_ENV` set to `test`.
+Through the mix config it is also possible to run setup mix tasks prior to
+running your test suite.  You can take advantage the `setup_tasks` to, for example,
+ensure your database is configured before your tests start.
+
+
+```elixir
+# config/config.exs
+use Mix.Config
+
+if Mix.env == :dev do
+  config :mix_test_watch,
+    setup_tasks: [
+      "ecto.drop --quiet",
+      "ecto.create --quiet",
+      "ecto.migrate"
+    ]
+end
+```
+
+Setup tasks are run in the order they appear in the list, and the progression will
+stop if any command returns a non-zero exit code.  They will only run once.
+
+All setup tasks are run with `MIX_ENV` set to `test`.
 
 
 ## Passing Arguments To Tasks

--- a/lib/mix_test_watch.ex
+++ b/lib/mix_test_watch.ex
@@ -17,6 +17,7 @@ defmodule MixTestWatch do
     put_config(args)
     :ok = Application.ensure_started(:fs)
     :ok = Application.ensure_started(:mix_test_watch)
+    Watcher.run_setup_tasks
     Watcher.run_tasks
     no_halt_unless_in_repl()
   end

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -4,6 +4,7 @@ defmodule MixTestWatch.Config do
   """
 
   @default_runner MixTestWatch.PortRunner
+  @default_setup_tasks ~w()
   @default_tasks ~w(test)
   @default_clear false
   @default_timestamp false
@@ -12,7 +13,8 @@ defmodule MixTestWatch.Config do
   @default_cli_executable "mix"
 
 
-  defstruct tasks:            @default_tasks,
+  defstruct setup_tasks:      @default_setup_tasks,
+            tasks:            @default_tasks,
             clear:            @default_clear,
             timestamp:        @default_timestamp,
             runner:           @default_runner,
@@ -27,6 +29,7 @@ defmodule MixTestWatch.Config do
   """
   def new(cli_args \\ []) do
     %__MODULE__{
+      setup_tasks:       get_setup_tasks(),
       tasks:             get_tasks(),
       clear:             get_clear(),
       timestamp:         get_timestamp(),
@@ -41,6 +44,10 @@ defmodule MixTestWatch.Config do
 
   defp get_runner do
     Application.get_env(:mix_test_watch, :runner, @default_runner)
+  end
+
+  defp get_setup_tasks do
+    Application.get_env(:mix_test_watch, :setup_tasks, @default_setup_tasks)
   end
 
   defp get_tasks do

--- a/lib/mix_test_watch/runner.ex
+++ b/lib/mix_test_watch/runner.ex
@@ -25,6 +25,14 @@ defmodule MixTestWatch.Runner do
     :ok
   end
 
+  @doc """
+  Run the setup tasks prior to running the real tests
+  """
+  def run_once(%Config{} = config) do
+    IO.puts "\nRunning setup_tasks (just once)..."
+    :ok = config.runner.run(config |> Map.put(:tasks, config.setup_tasks))
+    :ok
+  end
 
   #
   # Internal functions

--- a/lib/mix_test_watch/watcher.ex
+++ b/lib/mix_test_watch/watcher.ex
@@ -16,6 +16,10 @@ defmodule MixTestWatch.Watcher do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
+  def run_setup_tasks do
+    GenServer.cast(__MODULE__, :run_setup_tasks)
+  end
+
   def run_tasks do
     GenServer.cast(__MODULE__, :run_tasks)
   end
@@ -30,6 +34,12 @@ defmodule MixTestWatch.Watcher do
   def init(_) do
     :ok = :fs.subscribe
     {:ok, []}
+  end
+
+  def handle_cast(:run_setup_tasks, state) do
+    config = get_config()
+    MTW.Runner.run_once(config)
+    {:noreply, state}
   end
 
   def handle_cast(:run_tasks, state) do


### PR DESCRIPTION

Great lib!

I have a suggested improvement for dealing with libraries with databases, as the *new* approach is to add an `aliases` for test, but that breaks `mix test.watch` (at least for me).

This feature allows certain `setup_tasks` to be run just once.