### PR TITLE
Add :ansi_enabled config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add it to your dependencies:
 ```elixir
 # mix.exs (Elixir 1.4)
 def deps do
-  [{:mix_test_watch, "~> 0.3", only: :dev, runtime: false}]  
+  [{:mix_test_watch, "~> 0.3", only: :dev, runtime: false}]
 end
 ```
 
@@ -107,6 +107,24 @@ if Mix.env == :dev do
   config :mix_test_watch,
     exclude: [~r/db_migration\/.*/,
               ~r/useless_.*\.exs/]
+end
+```
+
+## Forcing ANSI colors in the terminal
+
+The config `:force_colors` is defaulted to `true` which will force the
+console to have [ANSI coloring](https://hexdocs.pm/elixir/IO.ANSI.html#enabled?/0).
+
+If Elixir can detect during startup that both `stdout` and `stderr` are terminals,
+then you set the value `false`, for example shown below.
+
+```elixir
+# config/config.exs
+use Mix.Config
+
+if Mix.env == :dev do
+  config :mix_test_watch,
+    :force_colors false
 end
 ```
 

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -10,6 +10,7 @@ defmodule MixTestWatch.Config do
   @default_exclude []
   @default_extra_extensions []
   @default_cli_executable "mix"
+  @default_force_colors true
 
 
   defstruct tasks:            @default_tasks,
@@ -19,6 +20,7 @@ defmodule MixTestWatch.Config do
             exclude:          @default_exclude,
             extra_extensions: @default_extra_extensions,
             cli_executable:   @default_cli_executable,
+            force_colors:     @default_force_colors,
             cli_args:         []
 
   @spec new([String.t]) :: %__MODULE__{}
@@ -33,6 +35,7 @@ defmodule MixTestWatch.Config do
       runner:            get_runner(),
       exclude:           get_excluded(),
       cli_executable:    get_cli_executable(),
+      force_colors:      get_force_colors(),
       cli_args:          cli_args,
       extra_extensions:  get_extra_extensions(),
     }
@@ -62,6 +65,11 @@ defmodule MixTestWatch.Config do
   defp get_cli_executable do
     Application.get_env(:mix_test_watch, :cli_executable,
                         @default_cli_executable)
+  end
+
+  defp get_force_colors do
+    Application.get_env(:mix_test_watch, :force_colors,
+                        @default_force_colors)
   end
 
   defp get_extra_extensions do

--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -28,11 +28,17 @@ defmodule MixTestWatch.PortRunner do
   end
 
 
-  @ansi "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+  defp ansi(%{force_colors: false}) do
+    []
+  end
+
+  defp ansi(%{force_colors: true}) do
+    ["do", "run -e 'Application.put_env(:elixir, :ansi_enabled, true);',"]
+  end
 
   defp task_command(task, config) do
     args = Enum.join(config.cli_args, " ")
-    [config.cli_executable, "do", @ansi <> ",", task, args]
+    [config.cli_executable] ++ ansi(config) ++ [task, args]
     |> Enum.filter(&(&1))
     |> Enum.join(" ")
     |> fn(command) -> "MIX_ENV=test #{command}" end.()

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -19,5 +19,19 @@ defmodule MixTestWatch.PortRunnerTest do
               <> "'Application.put_env(:elixir, :ansi_enabled, true);', test"
       assert PortRunner.build_tasks_cmds(config) == expected
     end
+
+    test "take the command force_colors set to false" do
+      config = %Config{ force_colors: false }
+      expected = "MIX_ENV=test mix test"
+      assert PortRunner.build_tasks_cmds(config) == expected
+    end
+
+    test "take the command force_colors set to true" do
+      config = %Config{ force_colors: true }
+      expected = "MIX_ENV=test mix do run -e "
+              <> "'Application.put_env(:elixir, :ansi_enabled, true);', test"
+      assert PortRunner.build_tasks_cmds(config) == expected
+    end
+
   end
 end


### PR DESCRIPTION

When testing using `mix test.watch` with a database, I was still encountering the database lock problem.  I traced it down to the `mix do ...` with the `:ansi_enabled` property.  I don't know much about the need to force that value to be true, so I put in place a config to `:ignore` it, which will just call `mix test` directly. 