### PR TITLE
Add default exclude for Emacs

### DIFF
--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -7,7 +7,7 @@ defmodule MixTestWatch.Config do
   @default_tasks ~w(test)
   @default_clear false
   @default_timestamp false
-  @default_exclude []
+  @default_exclude [~r/\.#/]
   @default_extra_extensions []
   @default_cli_executable "mix"
 

--- a/test/mix_test_watch/config_test.exs
+++ b/test/mix_test_watch/config_test.exs
@@ -25,6 +25,11 @@ defmodule MixTestWatch.ConfigTest do
     end
   end
 
+  test ":exclude contains common editor temp/swap files by default" do
+    config = Config.new
+    assert ~r/\.#/ in config.exclude # Emacs lock symlink
+  end
+
   test "new/1 takes :extra_extensions from the env" do
     TemporaryEnv.set :mix_test_watch, extra_extensions: [".haml"] do
       config = Config.new


### PR DESCRIPTION
See #72. I propose adding excludes one commit at a time so it's easier to trace back what editor it is for.