### PR TITLE
fixes #61 (sort of) revert fs to 0.9.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule MixTestWatch.Mixfile do
 
   defp deps do
     [# File system event watcher
-     {:fs, "~> 2.12"},
+     {:fs, "~> 0.9.1"},
      # Style linter
      {:dogma, "~> 0.1", only: ~w(dev test)a},
      # App env state test helper


### PR DESCRIPTION
phoenix_live_reload reverted fs to 0.9.1
https://github.com/phoenixframework/phoenix_live_reload/commit/e54bf6fb301436797ff589e0b76a047bb79b6870

----

Squashed commit of the following:

commit dbb8023d543154fb1fe60cb9676a3d4499ee84b5
Author: William Volin <williamvolin@live.com>
Date:   Sat Mar 18 20:49:53 2017 -0500

    Update mix.exs

commit cdf812e271f7edd7dc5b753c5ed70a7a5cf25175
Author: William Volin <williamvolin@live.com>
Date:   Sat Mar 18 20:47:30 2017 -0500

    Update mix.exs

    fix fs version

-------------

This is a better PR than #75 (squashed, and up-to-date master)