### PR TITLE
:fs version changed to properly support WSL mode

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule MixTestWatch.Mixfile do
 
   defp deps do
     [# File system event watcher
-     {:fs, "~> 0.9.1"},
+     {:fs, "~> 3.4.0"},
      # Style linter
      {:dogma, "~> 0.1", only: ~w(dev test)a},
      # App env state test helper

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"dogma": {:hex, :dogma, "0.1.15", "5bceba9054b2b97a4adcb2ab4948ca9245e5258b883946e82d32f785340fd411", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
+  "fs": {:hex, :fs, "3.4.0", "6d18575c250b415b3cad559e6f97a4c822516c7bc2c10bfbb2493a8f230f5132", [], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "temporary_env": {:hex, :temporary_env, "1.0.1", "bdb05d9b6c7f782b16779988c83c3f1c2fb2540b902e5e1cf8afbfecbd8e801c", [:mix], [], "hexpm"}}


### PR DESCRIPTION
Hello!

  Seems that currently used fs version (0.9.2) doesn't fully support work in WSL (Windows subsystem on Linux, or "Windows Bash"): if you put project on Windows volume (/mnt/c/...) then the only changes would be noticed by test.watch are changes made from WSL itself. So it's impossible to use it with native Windows code editing tools like VS Code.
  But fs 3.4.0 works great even with native Windows apps.

BR