### PR TITLE
Remove fs dependency in favor of file_system

### DIFF
--- a/lib/mix_test_watch.ex
+++ b/lib/mix_test_watch.ex
@@ -15,7 +15,7 @@ defmodule MixTestWatch do
   def run(args \\ []) when is_list(args) do
     Mix.env(:test)
     put_config(args)
-    :ok = Application.ensure_started(:fs)
+    :ok = Application.ensure_started(:file_system)
     :ok = Application.ensure_started(:mix_test_watch)
     Watcher.run_tasks()
     no_halt_unless_in_repl()

--- a/mix.exs
+++ b/mix.exs
@@ -23,13 +23,13 @@ defmodule MixTestWatch.Mixfile do
   end
 
   def application do
-    [mod: {MixTestWatch, []}, applications: [:fs]]
+    [mod: {MixTestWatch, []}, applications: [:file_system]]
   end
 
   defp deps do
     # File system event watcher
     [
-      {:fs, "~> 0.9.1"},
+      {:file_system, "~> 0.2.1 or ~> 0.3"},
       # App env state test helper
       {:temporary_env, "~> 1.0", only: :test},
       # Documentation generator

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "dogma": {:hex, :dogma, "0.1.16", "3c1532e2f63ece4813fe900a16704b8e33264da35fdb0d8a1d05090a3022eef9", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "file_system": {:hex, :file_system, "0.2.4", "f0bdda195c0e46e987333e986452ec523aed21d784189144f647c43eaf307064", [], [], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "temporary_env": {:hex, :temporary_env, "1.0.1", "bdb05d9b6c7f782b16779988c83c3f1c2fb2540b902e5e1cf8afbfecbd8e801c", [:mix], [], "hexpm"},


### PR DESCRIPTION
Fixes #68 with `file_system` instead of `fs`.