### PR TITLE
don't start application

### DIFF
--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -34,7 +34,7 @@ defmodule MixTestWatch.PortRunner do
     |> Enum.join(" && ")
   end
 
-  @ansi "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+  @ansi "run --no-start -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
 
   defp task_command(task, config) do
     args = Enum.join(config.cli_args, " ")

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -9,7 +9,7 @@ defmodule MixTestWatch.PortRunnerTest do
       config = %Config{cli_args: ["--exclude", "integration"]}
 
       expected =
-        "MIX_ENV=test mix do run -e " <>
+        "MIX_ENV=test mix do run --no-start -e " <>
           "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test --exclude integration"
 
       assert PortRunner.build_tasks_cmds(config) == expected
@@ -19,7 +19,7 @@ defmodule MixTestWatch.PortRunnerTest do
       config = %Config{cli_executable: "iex -S mix"}
 
       expected =
-        "MIX_ENV=test iex -S mix do run -e " <>
+        "MIX_ENV=test iex -S mix do run --no-start -e " <>
           "'Application.put_env(:elixir, :ansi_enabled, true);', test"
 
       assert PortRunner.build_tasks_cmds(config) == expected


### PR DESCRIPTION
a bit of context for this change: i was using `mix test --no-start` before i switched to this project. when i switched i noticed, that some of my tests failed due to `process xy is already running` errors which was suspicious because beside adding & using this project nothing else happened.

weeping through the code i found the relevant part in `PortRunner`. when executing

```bash
mix test.watch --no-start test/handler/types/entrypoint_test.exs
```

it gets transformed to the following command:

```bash
sh -c "MIX_ENV=test mix do run -e 'Application.put_env(:elixir, :ansi_enabled, true);', \
                           test --no-start test/handler/types/entrypoint_test.exs
```

where you can see, that it passes `--no-start` to the underlying `mix test` command, but it does not for the previous `mix run` command which is in place to enable ansi colored printing - so in fact, while the `mix test` command _does not_ start the application, the `mix run` command actually does ..

i can see the following options:

1. passing all arguments we give to `mix test` to `mix run` as well. i'm hesitating to do this, since i'm pretty sure that `mix run` doesn't accept every argument that `mix test` is aware of - which would make it fail pretty hard.
2. passing `--no-start` to `mix run` only in case that it's present in the process arguments
3. always passing `--no-start` to `mix run`

where i did the latter, because i couldn't see any change in behaviour at all. option 2 would be my other choice, in case that it's breaking any behaviour that i'm not aware of.

WDYT @lpil ?
