### PR TITLE
Improve windows support

### DIFF
--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -20,7 +20,7 @@ defmodule MixTestWatch.PortRunnerTest do
       refute is_nil(args)
       assert Enum.at(args, 0) === "/c"
       assert Enum.at(args, 1) =~ ~r(^set MIX_ENV=test)
-      assert Enum.at(args, 1) =~ ~r(mix test$)
+      assert Enum.at(args, 1) =~ ~r( test$)
     end
 
     test "builds the right command for non-windows" do
@@ -28,7 +28,7 @@ defmodule MixTestWatch.PortRunnerTest do
       refute is_nil(args)
       assert Enum.at(args, 0) === "-c"
       assert Enum.at(args, 1) =~ ~r(^MIX_ENV=test)
-      assert Enum.at(args, 1) =~ ~r(mix test$)
+      assert Enum.at(args, 1) =~ ~r( test$)
     end
 
     @tag ansi: true

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -1,28 +1,58 @@
 defmodule MixTestWatch.PortRunnerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias MixTestWatch.PortRunner
   alias MixTestWatch.Config
 
+  setup context do
+    if (Map.has_key?(context, :ansi)) do
+      old_state = Application.get_env(:elixir, :ansi_enabled)
+      Application.put_env(:elixir, :ansi_enabled, context.ansi)
+      on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, old_state) end)
+    end
+
+    context
+  end
+
   describe "build_tasks_cmds/1" do
+    test "builds the right command for windows" do
+      assert {"cmd", args} = PortRunner.build_tasks_cmds({:win32, 10}, %Config{})
+      refute is_nil(args)
+      assert Enum.at(args, 0) === "/c"
+      assert Enum.at(args, 1) =~ ~r(^set MIX_ENV=test)
+      assert Enum.at(args, 1) =~ ~r(mix test$)
+    end
+
+    test "builds the right command for non-windows" do
+      assert {"sh", args} = PortRunner.build_tasks_cmds({:macos, 10}, %Config{})
+      refute is_nil(args)
+      assert Enum.at(args, 0) === "-c"
+      assert Enum.at(args, 1) =~ ~r(^MIX_ENV=test)
+      assert Enum.at(args, 1) =~ ~r(mix test$)
+    end
+
+    @tag ansi: true
+    test "ANSI is preserved when on in runner" do
+      assert {_, args} = PortRunner.build_tasks_cmds({:macos, 10}, %Config{})
+      assert Enum.at(args, 1) =~ ~r/Application.put_env\(:elixir, :ansi_enabled, true\)/
+    end
+
+    @tag ansi: false
+    test "ANSI isn't enabled when off in runner" do
+      assert {_, args} = PortRunner.build_tasks_cmds({:macos, 10}, %Config{})
+      refute Enum.at(args, 1) =~ ~r/Application.put_env\(:elixir, :ansi_enabled, true\)/
+    end
+
     test "appends commandline arguments from passed config" do
       config = %Config{cli_args: ["--exclude", "integration"]}
-
-      expected =
-        "MIX_ENV=test mix do run --no-start -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test --exclude integration"
-
-      assert PortRunner.build_tasks_cmds(config) == expected
+      assert {_, args} = PortRunner.build_tasks_cmds({:macos, 10}, config)
+      assert Enum.at(args, 1) =~ ~r/--exclude integration$/
     end
 
     test "take the command cli_executable from passed config" do
       config = %Config{cli_executable: "iex -S mix"}
-
-      expected =
-        "MIX_ENV=test iex -S mix do run --no-start -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', test"
-
-      assert PortRunner.build_tasks_cmds(config) == expected
+      assert {_, args} = PortRunner.build_tasks_cmds({:macos, 10}, config)
+      assert Enum.at(args, 1) =~ ~r/iex -S mix/
     end
   end
 end


### PR DESCRIPTION
The current version doesn't pass command-line arguments to the sub-tasks, and it doesn't support running multiple tasks via config.  This tries to address both issues.