### PR TITLE
Add Phoenix Migrations Directory to Default Exclude Regex Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ if Mix.env == :dev do
 end
 ```
 
+The default is `exclude: [~r/\.#/, ~r{priv/repo/migrations}]`.
+
 ## Compatibility Notes
 
 On Linux you may need to install `inotify-tools`.

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -7,7 +7,7 @@ defmodule MixTestWatch.Config do
   @default_tasks ~w(test)
   @default_clear false
   @default_timestamp false
-  @default_exclude [~r/\.#/]
+  @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
   @default_extra_extensions []
   @default_cli_executable "mix"
 

--- a/test/mix_test_watch/config_test.exs
+++ b/test/mix_test_watch/config_test.exs
@@ -31,6 +31,11 @@ defmodule MixTestWatch.ConfigTest do
     assert ~r/\.#/ in config.exclude
   end
 
+  test ":exclude contains default Phoenix migrations directory by default" do
+    config = Config.new()
+    assert ~r{priv/repo/migrations} in config.exclude
+  end
+
   test "new/1 takes :extra_extensions from the env" do
     TemporaryEnv.set :mix_test_watch, extra_extensions: [".haml"] do
       config = Config.new()


### PR DESCRIPTION
Add the default Phoenix migrations directory (`priv/repo/migrations`) to the default list of exclude regex patterns.

This addresses #52.