### PR TITLE
pass no-start option only if provided to main script

### DIFF
--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -34,12 +34,16 @@ defmodule MixTestWatch.PortRunner do
     |> Enum.join(" && ")
   end
 
-  @ansi "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
-
   defp task_command(task, config) do
     args = Enum.join(config.cli_args, " ")
 
-    [config.cli_executable, "do", @ansi <> ",", task, args]
+    ansi =
+      case Enum.member?(config.cli_args, "--no-start") do
+        true -> "run --no-start -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+        false -> "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+      end
+
+    [config.cli_executable, "do", ansi <> ",", task, args]
     |> Enum.filter(& &1)
     |> Enum.join(" ")
     |> (fn command -> "MIX_ENV=test #{command}" end).()

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -24,5 +24,16 @@ defmodule MixTestWatch.PortRunnerTest do
 
       assert PortRunner.build_tasks_cmds(config) == expected
     end
+
+    test "respect no-start commandline argument from passed config" do
+      config = %Config{cli_args: ["--exclude", "integration", "--no-start"]}
+
+      expected =
+        "MIX_ENV=test mix do run --no-start -e " <>
+          "'Application.put_env(:elixir, :ansi_enabled, true);', " <>
+          "test --exclude integration --no-start"
+
+      assert PortRunner.build_tasks_cmds(config) == expected
+    end
   end
 end


### PR DESCRIPTION
since #87 broke some things (for example ecto, reported on #93) here's a new try that passes `--no-start` only along in case that the main script is called with that option.

given that it's opt-in, it should be fine this time and not break something else.