### PR TITLE
Upgrade version in Usage section in README.md to "~> 0.8"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Add it to your dependencies:
 ```elixir
 # mix.exs (Elixir 1.4)
 def deps do
-  [{:mix_test_watch, "~> 0.6", only: :dev, runtime: false}]  
+  [{:mix_test_watch, "~> 0.8", only: :dev, runtime: false}]  
 end
 ```
 
 ```elixir
 # mix.exs (Elixir 1.3 and earlier)
 def deps do
-  [{:mix_test_watch, "~> 0.6", only: :dev}]
+  [{:mix_test_watch, "~> 0.8", only: :dev}]
 end
 ```
 


### PR DESCRIPTION
Since in #95 @lpil suggested me to upgrade my version to the latest version, so I've found out that because I just copy the one in Usage section in the README.md, which is not up to date, I've got an older version. So I just update it just in case someone happens to face the same problem :D