### PR TITLE
added tentative fix for windows command args parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 erl_crash.dump
 *.ez
 /doc
+.elixir_ls

--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -45,14 +45,13 @@ defmodule MixTestWatch.PortRunner do
         false ->
           case :os.type() do
             {:win32, _} ->
-              ~s(run -e "Application.put_env :elixir, :ansi_enabled, true;")
+              # ~s(run -e Application.put_env\(:elixir, :ansi_enabled, true\) )
+              "run -e \"\""
 
             _ ->
               "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
           end
       end
-
-    IO.inspect(ansi <> ",")
 
     [config.cli_executable, "do", ansi <> " ,", task, args]
     |> Enum.filter(& &1)


### PR DESCRIPTION
This solves part of the issue.

Since windows doesn't accept single quotes in the `mix run` command, I needed to make changes to accommodate the double quotes in the ansi command. However...

Apparently, there's when passed to `System.cmd` on windows, the escaped double quotes at double quotes produced by the `~s` gets passed directly with the backslash, throwing a compile error.

When peppering the code with `IO.inspect()`, I get this:

λ mix test.watch test/hello_web/views/my_single_test.exs
```
==> mix_test_watch
Compiling 4 files (.ex)

Running tests...
"run -e \"Application.put_env :elixir, :ansi_enabled, true;\","
"set MIX_ENV=test&& mix do run -e \"Application.put_env :elixir, :ansi_enabled, true;\" , test test/hello_web/views/my_single_test.exs"

** (TokenMissingError) nofile:1: missing terminator: " (for string starting at line 1)
    (elixir) lib/code.ex:232: Code.eval_string/3
    (elixir) lib/enum.ex:765: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:765: Enum.each/2
    (mix) lib/mix/tasks/run.ex:142: Mix.Tasks.Run.run/5
    (mix) lib/mix/tasks/run.ex:85: Mix.Tasks.Run.run/1
    (mix) lib/mix/task.ex:316: Mix.Task.run_task/3
```
with the first inspect line being the result of the sigil, and the 2nd inspect being the windows command version.

My google-fu fails me when it comes to this, I've no idea why the backslashes are being passed.

When I run it without the backslash directly in cmd prompt, it works:
```
λ set MIX_ENV=test&& mix do run -e "Application.put_env :elixir, :ansi_enabled, true;" , test test/hello_web/views/my_single_test.exs
warning: unused import Phoenix.View
  test/hello_web/views/my_single_test.exs:5

.

Finished in 0.07 seconds
1 test, 0 failures

Randomized with seed 913000
```

