### PR TITLE
Tasks with ability to ignore global arguments and select environment.

### DIFF
--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -26,42 +26,16 @@ defmodule MixTestWatch.Config do
   """
   def new(cli_args \\ []) do
     %__MODULE__{
-      tasks: get_tasks(),
-      clear: get_clear(),
-      timestamp: get_timestamp(),
-      runner: get_runner(),
-      exclude: get_excluded(),
-      cli_executable: get_cli_executable(),
+      tasks: get_config(:tasks, @default_tasks),
+      clear: get_config(:clear, @default_clear),
+      timestamp: get_config(:timestamp, @default_timestamp),
+      runner: get_config(:runner, @default_runner),
+      exclude: get_config(:exclude, @default_exclude),
+      cli_executable: get_config(:cli_executable, @default_cli_executable),
       cli_args: cli_args,
-      extra_extensions: get_extra_extensions()
+      extra_extensions: get_config(:extra_extensions, @default_extra_extensions)
     }
   end
 
-  defp get_runner do
-    Application.get_env(:mix_test_watch, :runner, @default_runner)
-  end
-
-  defp get_tasks do
-    Application.get_env(:mix_test_watch, :tasks, @default_tasks)
-  end
-
-  defp get_clear do
-    Application.get_env(:mix_test_watch, :clear, @default_clear)
-  end
-
-  defp get_timestamp do
-    Application.get_env(:mix_test_watch, :timestamp, @default_timestamp)
-  end
-
-  defp get_excluded do
-    Application.get_env(:mix_test_watch, :exclude, @default_exclude)
-  end
-
-  defp get_cli_executable do
-    Application.get_env(:mix_test_watch, :cli_executable, @default_cli_executable)
-  end
-
-  defp get_extra_extensions do
-    Application.get_env(:mix_test_watch, :extra_extensions, @default_extra_extensions)
-  end
+  defp get_config(key, default), do: Application.get_env(:mix_test_watch, key, default)
 end

--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -34,6 +34,9 @@ defmodule MixTestWatch.PortRunner do
     |> Enum.join(" && ")
   end
 
+  defp task_command({task, :ignore_cli_args}, config),
+    do: task_command(task, %{config | cli_args: []})
+
   defp task_command(task, config) do
     args = Enum.join(config.cli_args, " ")
 

--- a/lib/mix_test_watch/watcher.ex
+++ b/lib/mix_test_watch/watcher.ex
@@ -26,19 +26,21 @@ defmodule MixTestWatch.Watcher do
   # Genserver callbacks
   #
 
-  @spec init(String.t()) :: {:ok, %{args: String.t()}}
-
+  @spec init(any) :: :ignore | {:ok, []}
   def init(_) do
     opts = [dirs: [Path.absname("")], name: :mix_test_watcher]
+
     case FileSystem.start_link(opts) do
       {:ok, _} ->
         FileSystem.subscribe(:mix_test_watcher)
         {:ok, []}
+
       other ->
-        Logger.warn """
+        Logger.warn("""
         Could not start the file system monitor.
-        """
-        other
+        """)
+
+        {:stop, other}
     end
   end
 

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -18,7 +18,7 @@ defmodule MixTestWatch.PortRunnerTest do
     test "ignores cli_args if task has :ignore_cli_args in definition" do
       config = %Config{
         cli_args: ["--exclude", "integration"],
-        tasks: [{"test", :ignore_cli_args}]
+        tasks: [{"test", [ignore_cli_args: true]}]
       }
 
       expected =
@@ -28,10 +28,23 @@ defmodule MixTestWatch.PortRunnerTest do
       assert PortRunner.build_tasks_cmds(config) == expected
     end
 
+    test "uses specific env if it is present in task definition" do
+      config = %Config{
+        cli_args: [],
+        tasks: [{"test", [env: "dev"]}]
+      }
+
+      expected =
+        "MIX_ENV=dev mix do run -e " <>
+          "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test"
+
+      assert PortRunner.build_tasks_cmds(config) == expected
+    end
+
     test "ignores cli_args for with specific key in task" do
       config = %Config{
         cli_args: ["--exclude", "integration"],
-        tasks: ["test", {"credo", :ignore_cli_args}]
+        tasks: ["test", {"credo", [ignore_cli_args: true]}]
       }
 
       first_task_expected =

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -31,19 +31,19 @@ defmodule MixTestWatch.PortRunnerTest do
     test "ignores cli_args for with specific key in task" do
       config = %Config{
         cli_args: ["--exclude", "integration"],
-        tasks: [{"test", :ignore_cli_args}, "dogma"]
+        tasks: ["test", {"credo", :ignore_cli_args}]
       }
 
       first_task_expected =
         "MIX_ENV=test mix do run -e " <>
           "'Application.put_env(:elixir, :ansi_enabled, true);', " <>
-          "test "
+          "test --exclude integration"
 
       second_task_expected =
         "MIX_ENV=test mix do run -e 'Application.put_env(:elixir, :ansi_enabled, true);', " <>
-          "dogma --exclude integration"
+          "credo"
 
-      expected = first_task_expected <> "&& " <> second_task_expected
+      expected = first_task_expected <> " && " <> second_task_expected
       assert PortRunner.build_tasks_cmds(config) == expected
     end
 


### PR DESCRIPTION
Allows for an application to ignore the global `:cli_args` or run tasks in specific environments.

Ignoring the global `:cli_args` parameter is useful because you can run other tasks without passing arguments you don't want (such as `credo` with the --stale option).

Running a task on a specific environment is useful when you want the task is only available in said environment, such as `dialyzer` (which is generally only added in development environment and you don't want to rebuild the PLT).