### PR TITLE
Add wrapper script to ensure no zombie processes

### DIFF
--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -16,7 +16,8 @@ defmodule MixTestWatch.PortRunner do
         System.cmd("cmd", ["/C", "set MIX_ENV=test&& mix test"], into: IO.stream(:stdio, :line))
 
       _ ->
-        System.cmd("sh", ["-c", command], into: IO.stream(:stdio, :line))
+        Path.join(:code.priv_dir(:mix_test_watch), "zombie_killer")
+        |> System.cmd(["sh", "-c", command], into: IO.stream(:stdio, :line))
     end
 
     :ok

--- a/priv/zombie_killer
+++ b/priv/zombie_killer
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Start the program in the background
+exec "$@" &
+pid1=$!
+
+# Silence warnings from here on
+exec >/dev/null 2>&1
+
+# Read from stdin in the background and
+# kill running program when stdin closes
+exec 0<&0 $(
+  while read; do :; done
+  kill -KILL $pid1
+) &
+pid2=$!
+
+# Clean up
+wait $pid1
+ret=$?
+kill -KILL $pid2
+exit $ret


### PR DESCRIPTION
The `zombie_killer`  script was copied from the documentation in the Elixir lang Ports module (https://github.com/Javyre/elixir/blob/4da31098a84268d040e569590515744c02efb9cc/lib/elixir/lib/port.ex#L120).

See also https://github.com/elixir-lang/elixir/issues/9171.

Closes https://github.com/lpil/mix-test.watch/issues/100.