### PR TITLE
Improve zombie_killer compatability

### DIFF
--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -17,7 +17,7 @@ defmodule MixTestWatch.PortRunner do
 
       _ ->
         Path.join(:code.priv_dir(:mix_test_watch), "zombie_killer")
-        |> System.cmd(["sh", "-c", command], into: IO.stream(:stdio, :line))
+        |> System.cmd(["sh", "-c", "'" <> command <> "'"], into: IO.stream(:stdio, :line))
     end
 
     :ok
@@ -40,8 +40,8 @@ defmodule MixTestWatch.PortRunner do
 
     ansi =
       case Enum.member?(config.cli_args, "--no-start") do
-        true -> "run --no-start -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
-        false -> "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+        true -> "run --no-start -e \"Application.put_env(:elixir, :ansi_enabled, true);\""
+        false -> "run -e \"Application.put_env(:elixir, :ansi_enabled, true);\""
       end
 
     [config.cli_executable, "do", ansi <> ",", task, args]

--- a/priv/zombie_killer
+++ b/priv/zombie_killer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Start the program in the background
-exec "$@" &
+eval "$@" &
 pid1=$!
 
 # Silence warnings from here on
@@ -9,8 +9,8 @@ exec >/dev/null 2>&1
 
 # Read from stdin in the background and
 # kill running program when stdin closes
-exec 0<&0 $(
-  while read; do :; done
+0<&0 $(
+  while read UNUSED ; do :; done
   kill -KILL $pid1
 ) &
 pid2=$!

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -10,7 +10,7 @@ defmodule MixTestWatch.PortRunnerTest do
 
       expected =
         "MIX_ENV=test mix do run -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test --exclude integration"
+          "\"Application.put_env(:elixir, :ansi_enabled, true);\", " <> "test --exclude integration"
 
       assert PortRunner.build_tasks_cmds(config) == expected
     end
@@ -20,7 +20,7 @@ defmodule MixTestWatch.PortRunnerTest do
 
       expected =
         "MIX_ENV=test iex -S mix do run -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', test"
+          "\"Application.put_env(:elixir, :ansi_enabled, true);\", test"
 
       assert PortRunner.build_tasks_cmds(config) == expected
     end
@@ -30,7 +30,7 @@ defmodule MixTestWatch.PortRunnerTest do
 
       expected =
         "MIX_ENV=test mix do run --no-start -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', " <>
+          "\"Application.put_env(:elixir, :ansi_enabled, true);\", " <>
           "test --exclude integration --no-start"
 
       assert PortRunner.build_tasks_cmds(config) == expected


### PR DESCRIPTION
Problem:
- Combination of zombie_killer and test command quotes are causing
  the unit tests to not run

Solution:
- Remove use of exec in sh script because it is being used incorrectly
- Change command quoting to match what is conventionally used with sh -c

Fixes #110 