### PR TITLE
Add reference to mix_test_interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ On Linux you may need to install `inotify-tools`.
 You can enable desktop notifications with
 [ex_unit_notifier](https://github.com/navinpeiris/ex_unit_notifier).
 
+## Alternatives
+
+[mix_test_interactive](https://github.com/influxdata/mix_test_interactive) is based on `mix test.watch` but adds an interactive mode that allows you to dynamically change which tests to run.
 
 ## Licence
 


### PR DESCRIPTION
Closes #115 

As suggested in https://github.com/lpil/mix-test.watch/issues/115#issuecomment-759513881, this adds a reference to the new [mix_test_interactive](https://github.com/influxdata/mix_test_interactive) project as an alternative.

Thanks again for this project! I've used it so much, and it served as a great base for `mix_test_interactive`!