### PR TITLE
Misc doc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,26 @@
-/_build
-/deps
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-/doc
+
+# Ignore package tarball (built via "mix hex.build").
+mix_test_watch-*.tar
+
+# Temporary files for e.g. tests.
+/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ elixir:
 otp_release:
   - 20.0
   - 21.0
-  
+
 matrix:
   exclude:
   - otp_release: 21.0
     elixir: 1.5
-  
+
 env: MIX_ENV=test
 
 sudo: false # faster builds

--- a/README.md
+++ b/README.md
@@ -2,32 +2,46 @@ mix test.watch
 ==============
 
 [![Build Status](https://travis-ci.org/lpil/mix-test.watch.svg?branch=master)](https://travis-ci.org/lpil/mix-test.watch)
-[![Hex version](https://img.shields.io/hexpm/v/mix_test_watch.svg "Hex version")](https://hex.pm/packages/mix_test_watch)
-[![Hex downloads](https://img.shields.io/hexpm/dt/mix_test_watch.svg "Hex downloads")](https://hex.pm/packages/mix_test_watch)
+[![Module Version](https://img.shields.io/hexpm/v/mix_test_watch.svg)](https://hex.pm/packages/mix_test_watch)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/mix_test_watch/)
+[![Total Download](https://img.shields.io/hexpm/dt/mix_test_watch.svg)](https://hex.pm/packages/mix_test_watch)
+[![License](https://img.shields.io/hexpm/l/mix_test_watch.svg)](https://github.com/lpil/mix-test.watch/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/lpil/mix-test.watch.svg)](https://github.com/lpil/mix-test.watch/commits/master)
 
 Automatically run your Elixir project's tests each time you save a file.
-Because TDD is awesome.
+
+Because [Test-driven development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development)
+is awesome.
 
 
 ## Usage
 
 Add it to your dependencies:
 
+For [Elixir 1.4](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#application-inference)
+onwards:
+
 ```elixir
-# mix.exs (Elixir 1.4)
+# mix.exs
 def deps do
-  [{:mix_test_watch, "~> 1.0", only: :dev, runtime: false}]
+  [
+    {:mix_test_watch, "~> 1.0", only: :dev, runtime: false}
+  ]
 end
 ```
 
+For Elixir 1.3 and earlier:
+
 ```elixir
-# mix.exs (Elixir 1.3 and earlier)
+# mix.exs
 def deps do
-  [{:mix_test_watch, "~> 1.0", only: :dev}]
+  [
+    {:mix_test_watch, "~> 1.0", only: :dev}
+  ]
 end
 ```
 
-Run the mix task
+Run the mix task:
 
 ```
 mix test.watch
@@ -87,7 +101,7 @@ mix test.watch --stale
 ## Clearing The Console Before Each Run
 
 If you want mix test.watch to clear the console before each run, you can
-enable this option in your config/dev.exs as follows:
+enable this option in your `config/dev.exs` as follows:
 
 ```elixir
 # config/config.exs
@@ -130,11 +144,11 @@ You can enable desktop notifications with
 
 [mix_test_interactive](https://github.com/influxdata/mix_test_interactive) is based on `mix test.watch` but adds an interactive mode that allows you to dynamically change which tests to run.
 
-## Licence
+## Copyright and Licence
 
-```
 mix test.watch
-Copyright © 2015-present Louis Pilfold
+
+Copyright © 2015 Louis Pilfold
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),
@@ -153,4 +167,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-```

--- a/mix.exs
+++ b/mix.exs
@@ -1,39 +1,56 @@
 defmodule MixTestWatch.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/lpil/mix-test.watch"
   @version "1.0.2"
 
   def project do
     [
       app: :mix_test_watch,
       version: @version,
-      elixir: "~> 1.0",
+      elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      docs: docs(),
       name: "mix test.watch",
       description: "Automatically run tests when files change",
       package: [
         maintainers: ["Louis Pilfold"],
         licenses: ["MIT"],
-        links: %{"GitHub" => "https://github.com/lpil/mix-test.watch"},
+        links: %{
+          "Changelog" => "https://hexdocs.pm/mix_test_watch/changelog.html",
+          "GitHub" => @source_url
+        },
         files: ~w(LICENCE README.md CHANGELOG.md lib priv mix.exs)
       ]
     ]
   end
 
   def application do
-    [mod: {MixTestWatch, []}, applications: [:file_system]]
+    [
+      mod: {MixTestWatch, []},
+      applications: [:file_system]
+    ]
   end
 
   defp deps do
-    # File system event watcher
     [
+      # File system event watcher
       {:file_system, "~> 0.2.1 or ~> 0.3"},
       # App env state test helper
       {:temporary_env, "~> 2.0", only: :test},
       # Documentation generator
-      {:ex_doc, ">= 0.12.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["CHANGELOG.md", "README.md"],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}"
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,10 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.0", "e22b6434373b4870ea77b24df069dbac7002c1f483615e9ebfc0c37497e1c75c", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
-  "temporary_env": {:hex, :temporary_env, "2.0.1", "d4b5e031837e5619485e1f23af7cba7e897b8fd546eaaa8b10c812d642ec4546", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm", "c57508ddad47dfb8038ca6de1e616e66e9b87313220ac5d9817bc4a4dc2257b9"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
+  "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm", "0d50da6b04c58e101a3793b1600f9a03b86e3a8057b192ac1766013d35706fa6"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "temporary_env": {:hex, :temporary_env, "2.0.1", "d4b5e031837e5619485e1f23af7cba7e897b8fd546eaaa8b10c812d642ec4546", [:mix], [], "hexpm", "f9420044742b5f0479a7f8243e86b048b6a2d4878bce026a3615065b11199c27"},
 }


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main source doc for this Elixir library which
leverage on ExDoc features.

List of changes:
* Fix markdowns
* Set readme as main HTML page
* Add changelog to HTML page
* Tally minimum Elixir version with Travis CI
* Update license year
* Use common source url
* Add source reference
* Use and set latest ex_doc
* Badges and more badges!
* Revise content
* Update gitignore

Screenshot:

![Screenshot-20210224222022-2660x1462](https://user-images.githubusercontent.com/134518/109013973-ad7ee280-76ee-11eb-96c4-4ce12d606f35.png)
