### PR TITLE
Update `maybe_clear_terminal` to remove scrollback

### DIFF
--- a/lib/mix_test_watch/runner.ex
+++ b/lib/mix_test_watch/runner.ex
@@ -2,6 +2,8 @@ defmodule MixTestWatch.Runner do
   @moduledoc false
 
   alias MixTestWatch.Config
+  
+  @clear_ansi_escape_sequence "\x1bc"
 
   #
   # Behaviour specification
@@ -29,7 +31,7 @@ defmodule MixTestWatch.Runner do
   #
 
   defp maybe_clear_terminal(%{clear: false}), do: :ok
-  defp maybe_clear_terminal(%{clear: true}), do: :ok = IO.puts(IO.ANSI.clear() <> IO.ANSI.home())
+  defp maybe_clear_terminal(%{clear: true}), do: :ok = IO.puts(@clear_ansi_escape_sequence)
 
   defp maybe_print_timestamp(%{timestamp: false}), do: :ok
 


### PR DESCRIPTION
`IO.ANSI.clear` + `home` seem to not clear scrollback (atleast on macOS), i.e. it prints "one screen height" of blank space and resets the cursor to the first position. A little bit of digging through [ANSI escape codes](https://askubuntu.com/questions/25077/how-to-really-clear-the-terminal) led me to this solution. I'm not sure if this is the best approach/if there's a way to get the right sequence out from the `IO.ANSI` library.