### PR TITLE
Use the new child spec instead of deprecated Supervisor.Spec.worker/2

### DIFF
--- a/lib/mix_test_watch.ex
+++ b/lib/mix_test_watch.ex
@@ -26,10 +26,8 @@ defmodule MixTestWatch do
   #
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     children = [
-      worker(Watcher, [])
+      Watcher
     ]
 
     opts = [strategy: :one_for_one, name: Sup.Supervisor]

--- a/lib/mix_test_watch/watcher.ex
+++ b/lib/mix_test_watch/watcher.ex
@@ -14,7 +14,7 @@ defmodule MixTestWatch.Watcher do
   # Client API
   #
 
-  def start_link do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 


### PR DESCRIPTION
This is a minor fix for this deprecation warning.

<img width="653" alt="mix-test-watch error 2021-05-17 at 1 09 51 PM" src="https://user-images.githubusercontent.com/7563926/118555431-b18c3080-b730-11eb-9000-09aa76860649.png">
