### PR TITLE
Allow MIX_ENV/MIX_TARGET settings to pass through

### DIFF
--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -38,16 +38,10 @@ defmodule MixTestWatch.PortRunner do
   defp task_command(task, config) do
     args = Enum.join(config.cli_args, " ")
 
-    ansi =
-      case Enum.member?(config.cli_args, "--no-start") do
-        true -> "run --no-start -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
-        false -> "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
-      end
-
-    [config.cli_executable, "do", ansi <> ",", task, args]
+    [config.cli_executable, task, args]
     |> Enum.filter(& &1)
     |> Enum.join(" ")
-    |> (fn command -> "MIX_ENV=test #{command}" end).()
+    |> (fn command -> "ELIXIR_ERL_OPTIONS=\"-elixir ansi_enabled true\" #{command}" end).()
     |> String.trim()
   end
 end

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -8,9 +8,7 @@ defmodule MixTestWatch.PortRunnerTest do
     test "appends commandline arguments from passed config" do
       config = %Config{cli_args: ["--exclude", "integration"]}
 
-      expected =
-        "MIX_ENV=test mix do run -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test --exclude integration"
+      expected = "ELIXIR_ERL_OPTIONS=\"-elixir ansi_enabled true\" mix test --exclude integration"
 
       assert PortRunner.build_tasks_cmds(config) == expected
     end
@@ -18,9 +16,7 @@ defmodule MixTestWatch.PortRunnerTest do
     test "take the command cli_executable from passed config" do
       config = %Config{cli_executable: "iex -S mix"}
 
-      expected =
-        "MIX_ENV=test iex -S mix do run -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', test"
+      expected = "ELIXIR_ERL_OPTIONS=\"-elixir ansi_enabled true\" iex -S mix test"
 
       assert PortRunner.build_tasks_cmds(config) == expected
     end
@@ -29,8 +25,7 @@ defmodule MixTestWatch.PortRunnerTest do
       config = %Config{cli_args: ["--exclude", "integration", "--no-start"]}
 
       expected =
-        "MIX_ENV=test mix do run --no-start -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', " <>
+        "ELIXIR_ERL_OPTIONS=\"-elixir ansi_enabled true\" mix " <>
           "test --exclude integration --no-start"
 
       assert PortRunner.build_tasks_cmds(config) == expected


### PR DESCRIPTION
Prior to this change, `MIX_ENV=test` was forced and any
`preferred_cli_env` and `preferred_cli_target` configuration in the
`mix.exs` would look like it was ignored. In actuality,
`preferred_cli_*` wasn't ignored, but you'd have to set it on `do` based
on how ANSI color was enabled.

This change enables ANSI a different way so that the mix target is
passed through and can get the `preferred_cli_*` settings, if any.
Because of this `MIX_ENV` doesn't need to be forced any more.
