### PR TITLE
feat: add support for configuring the MIX_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ if Mix.env == :dev do
 end
 ```
 
+## Run tests with a custom mix environment
+
+```elixir
+# config/config.exs
+use Mix.Config
+
+if Mix.env == :dev do
+  config :mix_test_watch,
+    mix_env: :e2e
+end
+```
+
 ## Compatibility Notes
 
 On Linux you may need to install `inotify-tools`.

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -5,6 +5,7 @@ defmodule MixTestWatch.Config do
 
   @default_runner MixTestWatch.PortRunner
   @default_tasks ~w(test)
+  @default_env :test
   @default_clear false
   @default_timestamp false
   @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
@@ -18,7 +19,8 @@ defmodule MixTestWatch.Config do
             exclude: @default_exclude,
             extra_extensions: @default_extra_extensions,
             cli_executable: @default_cli_executable,
-            cli_args: []
+            cli_args: [],
+            mix_env: @default_env
 
   @spec new([String.t()]) :: %__MODULE__{}
   @doc """
@@ -33,8 +35,13 @@ defmodule MixTestWatch.Config do
       exclude: get_excluded(),
       cli_executable: get_cli_executable(),
       cli_args: cli_args,
-      extra_extensions: get_extra_extensions()
+      extra_extensions: get_extra_extensions(),
+      mix_env: get_mix_env()
     }
+  end
+
+  defp get_mix_env do
+    Application.get_env(:mix_test_watch, :mix_env, @default_env)
   end
 
   defp get_runner do

--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -13,7 +13,9 @@ defmodule MixTestWatch.PortRunner do
 
     case :os.type() do
       {:win32, _} ->
-        System.cmd("cmd", ["/C", "set MIX_ENV=test&& mix test"], into: IO.stream(:stdio, :line))
+        System.cmd("cmd", ["/C", "set MIX_ENV=#{config.mix_env}&& mix test"],
+          into: IO.stream(:stdio, :line)
+        )
 
       _ ->
         Path.join(:code.priv_dir(:mix_test_watch), "zombie_killer")
@@ -47,7 +49,7 @@ defmodule MixTestWatch.PortRunner do
     [config.cli_executable, "do", ansi <> ",", task, args]
     |> Enum.filter(& &1)
     |> Enum.join(" ")
-    |> (fn command -> "MIX_ENV=test #{command}" end).()
+    |> (fn command -> "MIX_ENV=#{config.mix_env} #{command}" end).()
     |> String.trim()
   end
 end

--- a/test/mix_test_watch/config_test.exs
+++ b/test/mix_test_watch/config_test.exs
@@ -53,6 +53,11 @@ defmodule MixTestWatch.ConfigTest do
     assert config.cli_args == []
   end
 
+  test "new/1 default mix_env to test" do
+    config = Config.new()
+    assert config.mix_env == :test
+  end
+
   test "new/1 takes :clear from the env" do
     TemporaryEnv.put :mix_test_watch, :clear, true do
       config = Config.new()

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -35,5 +35,15 @@ defmodule MixTestWatch.PortRunnerTest do
 
       assert PortRunner.build_tasks_cmds(config) == expected
     end
+
+    test "respect mix_env argument from passed config" do
+      config = %Config{mix_env: :myenv}
+
+      expected =
+        "MIX_ENV=myenv mix do run -e " <>
+          "'Application.put_env(:elixir, :ansi_enabled, true);', test"
+
+      assert PortRunner.build_tasks_cmds(config) == expected
+    end
   end
 end


### PR DESCRIPTION
Allow the `MIX_ENV` tests run under to be specified in config