### PR TITLE
Fix `Logger.warn/1` deprecation warning in Elixir 1.15

### DIFF
--- a/lib/mix_test_watch/watcher.ex
+++ b/lib/mix_test_watch/watcher.ex
@@ -35,9 +35,7 @@ defmodule MixTestWatch.Watcher do
         FileSystem.subscribe(:mix_test_watcher)
         {:ok, []}
       other ->
-        Logger.warn """
-        Could not start the file system monitor.
-        """
+        Logger.warning("Could not start the file system monitor.")
         other
     end
   end


### PR DESCRIPTION
Hi 👋 

I noticed the following warning when I was compiling a project using 1.15.5. 

```shell
warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
  lib/mix_test_watch/watcher.ex:38: MixTestWatch.Watcher.init/1
```

Seemed like a slam dunk so I made the change. Let me know if anything else is required.

P.S: commit message is wrong 😅