### PR TITLE
All configured tasks should execute even if they exit non-zero

### DIFF
--- a/lib/mix_test_watch/port_runner/port_runner.ex
+++ b/lib/mix_test_watch/port_runner/port_runner.ex
@@ -32,7 +32,7 @@ defmodule MixTestWatch.PortRunner do
   def build_tasks_cmds(config = %Config{}) do
     config.tasks
     |> Enum.map(&task_command(&1, config))
-    |> Enum.join(" && ")
+    |> Enum.join(" ; ")
   end
 
   defp task_command(task, config) do

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule MixTestWatch.Mixfile do
       elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps(),
       docs: docs(),
       name: "mix test.watch",
@@ -52,6 +53,13 @@ defmodule MixTestWatch.Mixfile do
       main: "readme",
       source_url: @source_url,
       source_ref: "v#{@version}"
+    ]
+  end
+
+  defp aliases do
+    [
+      fail: ["cmd false"],
+      success: ["cmd echo success"]
     ]
   end
 end

--- a/test/mix_test_watch/port_runner/port_runner_test.exs
+++ b/test/mix_test_watch/port_runner/port_runner_test.exs
@@ -1,6 +1,8 @@
 defmodule MixTestWatch.PortRunnerTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   alias MixTestWatch.PortRunner
   alias MixTestWatch.Config
 
@@ -35,5 +37,11 @@ defmodule MixTestWatch.PortRunnerTest do
 
       assert PortRunner.build_tasks_cmds(config) == expected
     end
+  end
+
+  test "run/1 executes all tasks regardless of exit code" do
+    config = %Config{tasks: ["fail", "success"]}
+
+    assert capture_io(fn -> PortRunner.run(config) end) =~ "success"
   end
 end


### PR DESCRIPTION
I prefer to run credo before tests, but tests will never execute if credo exits non-zero which happens even when there are just warnings and not errors. This ensures that all tasks execute regardless of their exit codes.