### PR TITLE
Enable colored ouput by changing default_cli_executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-Changelog
-=========
+# Changelog
+
+## v1.1.2 - 2024-01-30
+
+- Fixed terminal output text not always being displayed with colors.
 
 ## v1.1.1 - 2023-09-02
 

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -9,7 +9,7 @@ defmodule MixTestWatch.Config do
   @default_timestamp false
   @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
   @default_extra_extensions []
-  @default_cli_executable "mix"
+  @default_cli_executable ~s(elixir --erl "-elixir ansi_enabled true" -S mix)
 
   defstruct tasks: @default_tasks,
             clear: @default_clear,

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule MixTestWatch.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/lpil/mix-test.watch"
-  @version "1.1.1"
+  @version "1.1.2"
 
   def project do
     [


### PR DESCRIPTION
Fixes #49 thanks to @danielspofford

Explanation here: https://github.com/lpil/mix-test.watch/issues/49#issuecomment-1848837003