### PR TITLE
MixTestWatch.Watcher runs tasks asynchronously and restarts them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-Changelog
-=========
+# Changelog
+
+## v1.1.2 - 2024-30-01
+
+- `MixTestWatch.Watcher` runs tasks asynchronously.
+- `MixTestWatch.Watcher` restarts tasks upon detecting watched events.
+- `MixTestWatch.Watcher` logging the reason of tasks restarts.
 
 ## v1.1.1 - 2023-09-02
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule MixTestWatch.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/lpil/mix-test.watch"
-  @version "1.1.1"
+  @version "1.1.2"
 
   def project do
     [


### PR DESCRIPTION
- `MixTestWatch.Watcher` runs tasks asynchronously.
- `MixTestWatch.Watcher` restarts tasks upon detecting watched events.
- `MixTestWatch.Watcher` logging the reason of tasks restarts.
