### PR TITLE
Optionally clear the scrollback buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,26 @@ if Mix.env == :dev do
 end
 ```
 
+If you also want mix test.watch to clear the scrollback buffer when clearing
+the console, you can enable this option in your `config/dev.exs` as follows:
+
+```elixir
+# config/config.exs
+use Mix.Config
+
+if Mix.env == :dev do
+  config :mix_test_watch,
+    clear: true,
+    clear_scrollback: :macos_terminal
+end
+```
+
+The options for `clear_scrollback` are:
+
+- `:macos_terminal`
+- `:macos_iterm2`
+- a binary representing an ANSI sequence such as `"\e[3J"`
+
 ## Excluding files or directories
 
 To ignore changes from specific files or directories just add `exclude:` regexp

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -6,6 +6,7 @@ defmodule MixTestWatch.Config do
   @default_runner MixTestWatch.PortRunner
   @default_tasks ~w(test)
   @default_clear false
+  @default_clear_scrollback false
   @default_timestamp false
   @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
   @default_extra_extensions []
@@ -13,6 +14,7 @@ defmodule MixTestWatch.Config do
 
   defstruct tasks: @default_tasks,
             clear: @default_clear,
+            clear_scrollback: @default_clear,
             timestamp: @default_timestamp,
             runner: @default_runner,
             exclude: @default_exclude,
@@ -28,6 +30,7 @@ defmodule MixTestWatch.Config do
     %__MODULE__{
       tasks: get_tasks(),
       clear: get_clear(),
+      clear_scrollback: get_clear_scrollback(),
       timestamp: get_timestamp(),
       runner: get_runner(),
       exclude: get_excluded(),
@@ -47,6 +50,10 @@ defmodule MixTestWatch.Config do
 
   defp get_clear do
     Application.get_env(:mix_test_watch, :clear, @default_clear)
+  end
+
+  defp get_clear_scrollback do
+    Application.get_env(:mix_test_watch, :clear_scrollback, @default_clear_scrollback)
   end
 
   defp get_timestamp do

--- a/lib/mix_test_watch/runner.ex
+++ b/lib/mix_test_watch/runner.ex
@@ -29,7 +29,14 @@ defmodule MixTestWatch.Runner do
   #
 
   defp maybe_clear_terminal(%{clear: false}), do: :ok
-  defp maybe_clear_terminal(%{clear: true}), do: :ok = IO.puts(IO.ANSI.clear() <> IO.ANSI.home())
+
+  defp maybe_clear_terminal(%{clear: true} = config),
+    do: :ok = IO.puts(IO.ANSI.clear() <> maybe_clear_scrollback(config) <> IO.ANSI.home())
+
+  defp maybe_clear_scrollback(%{clear_scrollback: false}), do: ""
+  defp maybe_clear_scrollback(%{clear_scrollback: :macos_iterm2}), do: "\e[2J\e[3J\e[H"
+  defp maybe_clear_scrollback(%{clear_scrollback: :macos_terminal}), do: "\e[3J"
+  defp maybe_clear_scrollback(%{clear_scrollback: binary}) when is_binary(binary), do: binary
 
   defp maybe_print_timestamp(%{timestamp: false}), do: :ok
 


### PR DESCRIPTION
when clearing the screen.

Options:
- false
- :macos_terminal
- :macos_iterm2
- <a binary containing an ANSI escape sequence>

This makes it flexible for people who need to use different escape codes.