### PR TITLE
Change default exclusion regexes to binaries to support OTP 28

### DIFF
--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -7,7 +7,7 @@ defmodule MixTestWatch.Config do
   @default_tasks ~w(test)
   @default_clear false
   @default_timestamp false
-  @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
+  @default_exclude ["\.#", "priv/repo/migrations"]
   @default_extra_extensions []
   @default_cli_executable ~s(elixir --erl "-elixir ansi_enabled true" -S mix)
 

--- a/lib/mix_test_watch/path.ex
+++ b/lib/mix_test_watch/path.ex
@@ -27,7 +27,10 @@ defmodule MixTestWatch.Path do
 
   defp excluded?(config, path) do
     config.exclude
-    |> Enum.map(fn pattern -> Regex.match?(pattern, path) end)
+    |> Enum.map(fn
+      pattern when is_binary(pattern) -> pattern |> Regex.compile!() |> Regex.match?(path)
+      pattern -> Regex.match?(pattern, path)
+    end)
     |> Enum.any?()
   end
 

--- a/test/mix_test_watch/config_test.exs
+++ b/test/mix_test_watch/config_test.exs
@@ -19,21 +19,21 @@ defmodule MixTestWatch.ConfigTest do
   end
 
   test "new/1 takes :exclude from the env" do
-    TemporaryEnv.put :mix_test_watch, :exclude, [~r/migration_.*/] do
+    TemporaryEnv.put :mix_test_watch, :exclude, ["migration_.*"] do
       config = Config.new()
-      assert config.exclude == [~r/migration_.*/]
+      assert config.exclude == ["migration_.*"]
     end
   end
 
   test ":exclude contains common editor temp/swap files by default" do
     config = Config.new()
     # Emacs lock symlink
-    assert ~r/\.#/ in config.exclude
+    assert "\.#" in config.exclude
   end
 
-  test ":exclude contains default Phoenix migrations directory by default" do
+  test ":exclude contains default Ecto migrations directory by default" do
     config = Config.new()
-    assert ~r{priv/repo/migrations} in config.exclude
+    assert "priv/repo/migrations" in config.exclude
   end
 
   test "new/1 takes :extra_extensions from the env" do


### PR DESCRIPTION
OTP 28 changes the implementation for regexes, and as a result you can no longer use Regexes in module attributes.

I changed the defaults to strings of the patterns and added a function clause to first compile the regexes if they are binary. This means it is backwards compatible and the user can still configure actual Regexes instead of binary patterns.