### PR TITLE
Allow custom directories to be watched

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ if config_env() == :dev do
 end
 ```
 
+## Watching files in other locations
+
+To watch files in locations other than the project that `mix test.watch` is run within, add those paths to `extra_directories:` in your config:
+
+```elixir
+# config/config.exs
+import Config
+
+if Enum.member?([:dev, :test], config_env()) do
+  config :mix_test_watch, extra_directories: ["../other", "/home/user/examples"]
+end
+```
+
 ## Compatibility Notes
 
 On Linux you may need to install `inotify-tools`.

--- a/lib/mix_test_watch/config.ex
+++ b/lib/mix_test_watch/config.ex
@@ -10,6 +10,7 @@ defmodule MixTestWatch.Config do
   @default_exclude ["\\\.#", "priv/repo/migrations"]
   @default_extra_extensions []
   @default_cli_executable ~s(elixir --erl "-elixir ansi_enabled true" -S mix)
+  @default_directories [Path.absname("")]
 
   defstruct tasks: @default_tasks,
             clear: @default_clear,
@@ -17,6 +18,7 @@ defmodule MixTestWatch.Config do
             runner: @default_runner,
             exclude: @default_exclude,
             extra_extensions: @default_extra_extensions,
+            directories: @default_directories,
             cli_executable: @default_cli_executable,
             cli_args: []
 
@@ -28,6 +30,7 @@ defmodule MixTestWatch.Config do
           exclude: [String.t()],
           extra_extensions: [String.t()],
           cli_executable: String.t(),
+          directories: [String.t()],
           cli_args: [String.t()]
         }
 
@@ -43,6 +46,7 @@ defmodule MixTestWatch.Config do
       runner: get_runner(),
       exclude: get_excluded(),
       extra_extensions: get_extra_extensions(),
+      directories: get_directories(),
       cli_executable: get_cli_executable(),
       cli_args: cli_args
     }
@@ -66,10 +70,14 @@ defmodule MixTestWatch.Config do
 
   defp get_excluded do
     Application.get_env(:mix_test_watch, :exclude, @default_exclude)
-    |> Enum.map(fn 
+    |> Enum.map(fn
       pattern when is_binary(pattern) -> Regex.compile!(pattern)
       pattern = %Regex{} -> pattern
     end)
+  end
+
+  def get_directories do
+    @default_directories ++ List.wrap(Application.get_env(:mix_test_watch, :extra_directories, []))
   end
 
   defp get_cli_executable do

--- a/lib/mix_test_watch/watcher.ex
+++ b/lib/mix_test_watch/watcher.ex
@@ -29,7 +29,8 @@ defmodule MixTestWatch.Watcher do
   @spec init(String.t()) :: {:ok, Keyword.t()}
 
   def init(_) do
-    opts = [dirs: [Path.absname("")], name: :mix_test_watcher]
+    config = get_config()
+    opts = [dirs: config.directories, name: :mix_test_watcher]
 
     case FileSystem.start_link(opts) do
       {:ok, _} ->


### PR DESCRIPTION
This PR adds a configuration option (`extra_directories`) which takes a list of paths that are added to the file watchers when `mix test.watch` starts.

Use case: we are using ExUnit in a small Elixir app as a test harness to validate a set of json7 schemas and examples that form a conformance test suite for them. This validator does not reside in the same location as the schema and examples, but it is nice to be able to `mix test.watch` for changes made to them for immediate feedback and continuous checking when they change.